### PR TITLE
exclude_files config option to skip including unneccessary files on each request

### DIFF
--- a/src/Composer/AutoloadGenerator.php
+++ b/src/Composer/AutoloadGenerator.php
@@ -42,7 +42,7 @@ class AutoloadGenerator extends ComposerAutoloadGenerator
 	 *
 	 * @see https://github.com/composer/composer/blob/master/src/Composer/Autoload/AutoloadGenerator.php#L115
 	 */
-	public function dumpFiles(Composer $composer, $paths, $targetDir = 'composer', $suffix = '', $staticPhpVersion = 70000)
+	public function dumpFiles(Composer $composer, $paths, $excludePaths = [], $targetDir = 'composer', $suffix = '', $staticPhpVersion = 70000)
 	{
 		$installationManager = $composer->getInstallationManager();
 		$localRepo = $composer->getRepositoryManager()->getLocalRepository();
@@ -82,9 +82,18 @@ class AutoloadGenerator extends ComposerAutoloadGenerator
 			}
 		}
 
+
 		$paths = $this->parseAutoloadsTypeFiles($paths, $mainPackage);
 
 		$autoloads['files'] = array_merge($paths, $autoloads['files']);
+
+		// prepend vendor path to exclude paths
+		foreach ($excludePaths as &$path) {
+			$path = $vendorPath . '/' . $path;
+		}
+		$autoloads['files'] = array_filter($autoloads['files'], function($path) use ($excludePaths, $filesystem) {
+			return !in_array($filesystem->normalizePath($path), $excludePaths);
+		});
 
 		$includeFilesFilePath = $targetDir.'/autoload_files.php';
 		if ($includeFilesFileContents = $this->getIncludeFilesFile($autoloads['files'], $filesystem, $basePath, $vendorPath, $vendorPathCode52, $appBaseDirCode)) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -47,10 +47,16 @@ class Plugin implements PluginInterface, EventSubscriberInterface
 	{
 		$extraConfig = $this->composer->getPackage()->getExtra();
 
-		if (!array_key_exists('include_files', $extraConfig) || !is_array($extraConfig['include_files'])) {
+		/*if (!array_key_exists('include_files', $extraConfig) || !is_array($extraConfig['include_files'])) {
+			return;
+		}*/
+		$includeFiles = !empty($extraConfig['include_files']) ? $extraConfig['include_files'] : [];
+		$excludeFiles = !empty($extraConfig['exclude_files']) ? $extraConfig['exclude_files'] : [];
+		if (!$includeFiles && !$excludeFiles) {
 			return;
 		}
 
-		$this->generator->dumpFiles($this->composer, $extraConfig['include_files']);
+		//$this->generator->dumpFiles($this->composer, $extraConfig['include_files']);
+		$this->generator->dumpFiles($this->composer, $includeFiles, $excludeFiles);
 	}
 }


### PR DESCRIPTION
Paths should be relative to vendor folder.

Example:

```
"config": {
  "exclude_files": [
    "symfony/polyfill-mbstring/bootstrap.php",
    "symfony/polyfill-php56/bootstrap.php"
  ]
}
```

by: funkjedi#5